### PR TITLE
[Fix]camiones- Rediseño de la página de camiones

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -123,7 +123,7 @@ input::placeholder{
     background-position: center;
     background-repeat: no-repeat; /* Evita que se repita */
     height: 100vh; /* Asegura que cubra toda la altura de la ventana */
-    width: 100%; /
+    width: 100%; 
 }
 
 /* Logo */

--- a/public/assets/css/pages/camiones.css
+++ b/public/assets/css/pages/camiones.css
@@ -4,31 +4,40 @@
 
 /* Main Section */
 .main {
-    display: flex; 
-    justify-content: space-between; 
-    align-items: flex-start;  
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
     padding: 10px;
-    margin-top: -20px; 
-    flex-wrap: wrap; 
-    height: auto; 
-    overflow-y: auto; 
-    width: 100%; 
+    margin-top: -20px;
+    flex-wrap: wrap;
+    width: 100%;
 }
 
 /* Estilo para camion_1 y camion_2 */
 .camion_1, .camion_2 {
-    flex: 1;
+    flex: 1 1 48%; /* Esto asegura que las tarjetas ocupen el 48% del ancho */
     margin-right: 10px;
     padding: 10px;
     border-radius: 8px;
     text-align: left;
     overflow: hidden;
+    height: auto; /* Asegura que las tarjetas no cambien de tamaño */
 }
 
-.camion_1 h2, .camion_2 h2{
+.camion_1 h2, .camion_2 h2 {
     color: #296E03;
 }
 
+/* Dropdown: Establecer un tamaño fijo */
+.accordion-button {
+    height: 40px; /* Establecer una altura fija para los botones */
+    font-size: 14px;
+}
+
+.accordion-body {
+    max-height: 300px;
+    overflow-y: auto;
+}
 /* Rutas: Distribuir en dos columnas */
 .routes {
     display: flex;
@@ -75,18 +84,40 @@
     background-color: #218838;
 }
 
+.col-md-6 {
+    width: 100%; 
+}
+
+h5 {
+    font-size: 2rem;
+    color: #218838 !important;
+}
+
+
+
+
 /* Estilos responsivos */
 @media (max-width: 768px) {
-    .main {
-        flex-direction: column;
-        align-items: center;
-        height: auto; 
-        padding: 10px;
-        overflow-y: auto; 
+
+    /* Asegura que todo el contenido esté centrado vertical y horizontalmente */
+    .content {
+        min-height: 100vh; /* Ocupa toda la altura de la pantalla */
+        padding: 20px;
+        margin-bottom: 0px;
+        margin-left: 0px;
     }
 
+    .main {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+    }
+
+
     .camion_1, .camion_2 {
-        width: 100%; 
+        width: 100%;
         margin-right: 0;
         margin-bottom: 20px;
     }
@@ -102,6 +133,43 @@
 
     .btn-como-llegar {
         width: 100%; 
+        font-size: 16px;
+    }
+
+    /* Alinea las tarjetas al centro */
+    .col-12.col-md-6 {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 20px;
+    }
+
+    .card {
+        width: 90%; /* Ajusta el tamaño de la tarjeta */
+        max-width: 400px; /* Limita el ancho de las tarjetas */
+    }
+
+    /* Reduce el tamaño del título en pantallas pequeñas */
+    h5.card-title {
+        font-size: 1rem;
+    }
+
+    /* Reduce el tamaño de los botones del acordeón */
+    .accordion-button {
+        font-size: 0.97rem !important;
+        white-space: nowrap; /* Evita el salto de línea */
+        overflow: hidden;
+        text-overflow: ellipsis; /* Muestra '...' si el texto es demasiado largo */
+    }
+
+    /* Reducir el tamaño del texto de las listas */
+    .accordion-body,
+    .list-group {
+        font-size: 0.90rem !important;
+    }
+
+    /* Ajusta el tamaño de los botones */
+    .btn-ver-graficos {
+        width: 100%;
         font-size: 16px;
     }
 }

--- a/public/assets/css/pages/login_page.css
+++ b/public/assets/css/pages/login_page.css
@@ -20,7 +20,7 @@
     background-position: center;
     background-repeat: no-repeat; /* Evita que se repita */
     height: 100vh; /* Asegura que cubra toda la altura de la ventana */
-    width: 100%; /
+    width: 100%; 
 }
 
 /* Logo */

--- a/public/camiones.html
+++ b/public/camiones.html
@@ -10,10 +10,8 @@
     <link rel="stylesheet" href="./assets/css/pages/page_laterales.css">
     <link rel="stylesheet" href="./assets/css/pages/camiones.css">
     <script src="./src/components/sidebar.js"></script> 
-    <script src="./src/views/UsuarioLogueado.js" defer type="module"></script>
 </head>
 <body>
-    
     <div class="wrapper">
         <!-- Sidebar -->
         <nav class="sidebar" id="aside">
@@ -40,132 +38,176 @@
                     <button class="profile-btn" type="button" id="btn-user" onclick="toggleMenu()" ><img id="userProfilePicture" src="assets/imagenes/perfil.jpg"></button>
                 </div>
             </header>
-
-                        <!-- Superposición de fondo -->
-                        <div id="menu-overlay" onclick="toggleMenu()"></div>
-                        <!-- Menú deslizante del usuario para que este entre al menu de configuracion-->
-                        <div id="user-menu">
-                            <i class="bi bi-x close-menu" onclick="toggleMenu()"></i>
-                            <p id ="userName"></p>
-                            <ul>
-                                <li><i class="bi bi-person"></i> <a href="./perfil.html">Tu perfil</a></li>
-                                <li><i class="bi bi-bookmark"></i> <a href="#guardado">Guardado</a></li>
-                                <li><i class="bi bi-bell"></i> <a href="#notificaciones">Notificaciones</a></li>
-                                <li><i class="bi bi-map"></i> <a href="#rutas">Tus Rutas</a></li>
-                                <li><i class="bi bi-share"></i> <a href="#compartir">Compartir</a></li>
-                                <li><i class="bi bi-gear"></i> <a href="#configuracion">Configuración</a></li>
-                                <li><i class="bi bi-box-arrow-right"></i> <a href="#" id="logout-btn">Cerrar Sesión</a></li>        
-                            </ul>
-                        </div>
+            
+            <!-- Superposición de fondo -->
+            <div id="menu-overlay" onclick="toggleMenu()"></div>
+            <!-- Menú deslizante del usuario para que este entre al menu de configuracion-->
+            <div id="user-menu">
+                <i class="bi bi-x close-menu" onclick="toggleMenu()"></i>
+                <p id="userName"></p>
+                <ul>
+                    <li><i class="bi bi-person"></i> <a href="./perfil.html">Perfil</a></li>
+                    <li><i class="bi bi-share"></i> <a href="#compartir">Compartir</a></li>
+                    <li><i class="bi bi-box-arrow-right"></i> <a href="#" id="logout-btn">Cerrar Sesión</a></li>
+                </ul>
+            </div>
 
             <!-- Main Section -->
-            <section class="main">
-                <div class="camion_1">
-                    <h2>Camión C01</h2>
-                    <h4>Inicio: Central de autobuses</h4>
-                    <h4>Inicio: Colonia Matamoros</h4>
-                    <div class="routes">
-                        <!-- Primer columna de rutas -->
-                        <div class="column">
-                            <ul style="list-style-type: disc;">
-                                <li>Cruce Carretera Yahualica-Tepa y San Luis</li>
-                                <li>López Mateos y Cruce Carretera Yahualica-Tepa</li>
-                                <li>López Mateos</li>
-                                <li>Cruce López Mateos y Las Palmas</li>
-                                <li>Glorieta Colonias</li>
-                                <li>Cruce López Mateos y Mayas</li>
-                                <li>Calle López Mateos</li>
-                                <li>Cruce López Mateos y Aquiles Serdán</li>
-                                <li>Cruce López Mateos y Gómez Morín</li>
-                                <li>Cruce Félix Ramos y González Gallo</li>
-                                <li>Sagrada Familia</li>
-                                <li>Cruce González Gallo y J. Cruz Ramírez</li>
-                                <li>Cruce Vallarta y San Martín</li>
-                                <li>Colegio Morelos</li>
-                                <li>Parque del Beso</li>
-                                <li>Cruce Niños Héroes y Revolución</li>
-                                <li>Cruce J. Caro Galindo y Matamoros</li>
-                                <li>Calle Matamoros</li>
-                            </ul>
+            <section class="main container-fluid py-4">
+                <div class="row g-4 d-flex flex-wrap justify-content-between" style="width: 95%;">
+                    <!-- Camión C01 -->
+                    <div class="col-12 col-md-6">
+                        <div class="card shadow-sm h-100">
+                            <div class="card-body d-flex flex-column">
+                                <h5 class="card-title">Camión C01</h5>
+
+                                <!-- Dropdown para paradas -->
+                                <div class="paradas-container flex-grow-1 mb-3" style="max-height: 300px; overflow-y: auto;">
+                                    <div class="accordion" id="accordionC01">
+                                        <div class="accordion-item">
+                                            <h3 class="accordion-header" id="headingC01_1">
+                                                <button class="accordion-button collapsed fs-4" type="button" data-bs-toggle="collapse" data-bs-target="#collapseC01_1" aria-expanded="false" aria-controls="collapseC01_1">
+                                                    CUALTOS-Central
+                                                </button>
+                                            </h3>
+                                            <div id="collapseC01_1" class="accordion-collapse collapse" aria-labelledby="headingC01_1" data-bs-parent="#accordionC01">
+                                                <div class="accordion-body">
+                                                    <ul class="list-group list-group-flush fs-5">
+                                                        <li class="list-group-item">Cruce Carretera Yahualica-Tepa y San Luis</li>
+                                                        <li class="list-group-item">López Mateos y Cruce Carretera Yahualica-Tepa</li>
+                                                        <li class="list-group-item">López Mateos</li>
+                                                        <li class="list-group-item">Cruce López Mateos y Las Palmas</li>
+                                                        <li class="list-group-item">Glorieta Colonias</li>
+                                                        <li class="list-group-item">Cruce López Mateos y Mayas</li>
+                                                        <li class="list-group-item">Calle López Mateos</li>
+                                                        <li class="list-group-item">Cruce López Mateos y Aquiles Serdán</li>
+                                                        <li class="list-group-item">Cruce López Mateos y Gómez Morín</li>
+                                                        <li class="list-group-item">Cruce Félix Ramos y González Gallo</li>
+                                                        <li class="list-group-item">Sagrada Familia</li>
+                                                        <li class="list-group-item">Cruce González Gallo y J. Cruz Ramírez</li>
+                                                        <li class="list-group-item">Cruce Vallarta y San Martín</li>
+                                                        <li class="list-group-item">Colegio Morelos</li>
+                                                        <li class="list-group-item">Parque del Beso</li>
+                                                        <li class="list-group-item">Cruce Niños Héroes y Revolución</li>
+                                                        <li class="list-group-item">Cruce J. Caro Galindo y Matamoros</li>
+                                                        <li class="list-group-item">Calle Matamoros</li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="accordion-item">
+                                            <h3 class="accordion-header" id="headingC01_2">
+                                                <button class="accordion-button collapsed fs-4" type="button" data-bs-toggle="collapse" data-bs-target="#collapseC01_2" aria-expanded="false" aria-controls="collapseC01_2">
+                                                    Central-CUALTOS
+                                                </button>
+                                            </h3>
+                                            <div id="collapseC01_2" class="accordion-collapse collapse" aria-labelledby="headingC01_2" data-bs-parent="#accordionC01">
+                                                <div class="accordion-body">
+                                                    <ul class="list-group list-group-flush fs-5">
+                                                        <li class="list-group-item">Central</li>
+                                                        <li class="list-group-item">Oxxo, Calle Hidalgo</li>
+                                                        <li class="list-group-item">IMSS</li>
+                                                        <li class="list-group-item">Cruce 5 de febrero e Independencia</li>
+                                                        <li class="list-group-item">Cruce Independencia y Colón</li>
+                                                        <li class="list-group-item">Cruce Independencia y San Martín</li>
+                                                        <li class="list-group-item">Cruce 16 de sep. y Antonio Rojas</li>
+                                                        <li class="list-group-item">Cruce Antonio Rojas y Álvaro Obregón</li>
+                                                        <li class="list-group-item">Cruce Gral. Anaya y González Gallo</li>
+                                                        <li class="list-group-item">Cruce Gral. Anaya y Aquiles Serdán</li>
+                                                        <li class="list-group-item">Cruce José Gpe y López Mateos</li>
+                                                        <li class="list-group-item">Cruce López Mateos y Mayas</li>
+                                                        <li class="list-group-item">Glorieta Colonias</li>
+                                                        <li class="list-group-item">Cruce Av. López Mateos y Alemania</li>
+                                                        <li class="list-group-item">Cruce Hacienda Mirandilla y Trasquila</li>
+                                                        <li class="list-group-item">Cruce Hacienda Trasquilla y López Mateos</li>
+                                                        <li class="list-group-item">Cruce km 71 y Avila Camacho</li>
+                                                        <li class="list-group-item">Cruce km 71 y Rafael Casillas Aceves</li>
+                                                        <li class="list-group-item">CUALTOS</li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <button class="btn ver-graficos w-20 mx-auto d-block toggle-ruta" onclick="window.location.href='./mapa.html'">
+                                    <i class="bi bi-map me-1"></i> Ver gráfico de la ruta
+                                </button>
+                            </div>
                         </div>
-            
-                        <!-- Segunda columna de rutas -->
-                        <div class="column">
-                            <ul style="list-style-type: disc;">
-                                <li>Central</li>
-                                <li>Oxxo, Calle Hidalgo</li>
-                                <li>IMSS</li>
-                                <li>Cruce 5 de febrero e Independencia</li>
-                                <li>Cruce Independencia y Colón</li>
-                                <li>Cruce Independencia y San Martín</li>
-                                <li>Cruce 16 de sep. y Antonio Rojas</li>
-                                <li>Cruce Antonio Rojas y Álvaro Obregón</li>
-                                <li>Cruce Gral. Anaya y González Gallo</li>
-                                <li>Cruce Gral. Anaya y Aquiles Serdán</li>
-                                <li>Cruce José Gpe y López Mateos</li>
-                                <li>Cruce López Mateos y Mayas</li>
-                                <li>Glorieta Colonias</li>
-                                <li>Cruce Av. López Mateos y Alemania</li>
-                                <li>Cruce Hacienda Mirandilla y Trasquila</li>
-                                <li>Cruce Hacienda Trasquilla y López Mateos</li>
-                                <li>Cruce km 71 y Avila Camacho</li>
-                                <li>Cruce km 71 y Rafael Casillas Aceves</li>
-                                <li>CUALTOS</li>
-                            </ul>
-                        </div>
-                        <button class="ver-graficos" onclick="window.location.href = './mapa.html'">Ver grafico de la ruta</button>
                     </div>
-                </div>
-            
-                <!-- Segunda sección: Camión 2 -->
-                <div class="camion_2">
-                    <h2>Camión C02</h2>
-                    <h4>Inicio: Central de autobuses</h4>
-                    <h4>Inicio: Colonia Matamoros</h4>
-                    <div class="routes">
-                        <!-- Primer columna de rutas para camion_2 -->
-                        <div class="column">
-                            <ul style="list-style-type: disc;">
-                                <li>Cruce Manuel Altamirano y Gpe. Victoria</li>
-                                <li>Cruce Manuel doblado y matamoros</li>
-                                <li>Cruce Matamoros y Morelos</li>
-                                <li>Cruce H. Garza y Moctezuma</li>
-                                <li>Gonzalez Gallo</li>
-                                <li>Oxxo Gonzalez Gallo</li>
-                                <li>Escuela 5 de mayo</li>
-                                <li>Cruce Gral Anaya y González Hermosillo</li>
-                                <li>Gral Anaya y Aquiles Serdán</li>
-                                <li>Cruce Hda. la Trasquila y Mirandilla</li>
-                                <li>Cruce Hda. Sta. Ana Apacueco y la Mina</li>
-                                <li>Cruce Hda. La Mina y de Guadalupe</li>
-                                <li>Cruce Álvaro Obregón y J. Luis Velazco</li>
-                                <li>Cruce J. Luis Velazco y Allende</li>
-                                <li>Cruce Madero y Avila Camacho</li>
-                                <li>Cruce Mapelo y Félix Ramos</li>
-                            </ul>
+
+                    <!-- Camión C02 -->
+                    <div class="col-12 col-md-6">
+                        <div class="card shadow-sm h-100">
+                            <div class="card-body d-flex flex-column">
+                                <h5 class="card-title">Camión C02</h5>
+
+                                <!-- Dropdown para paradas -->
+                                <div class="paradas-container flex-grow-1 mb-3" style="max-height: 300px; overflow-y: auto;">
+                                    <div class="accordion" id="accordionC02">
+                                        <div class="accordion-item">
+                                            <h3 class="accordion-header" id="headingC02_1">
+                                                <button class="accordion-button collapsed fs-4" type="button" data-bs-toggle="collapse" data-bs-target="#collapseC02_1" aria-expanded="false" aria-controls="collapseC02_1">
+                                                    Rutas de Camión C02
+                                                </button>
+                                            </h3>
+                                            <div id="collapseC02_1" class="accordion-collapse collapse" aria-labelledby="headingC02_1" data-bs-parent="#accordionC02">
+                                                <div class="accordion-body">
+                                                    <ul class="list-group list-group-flush fs-5">
+                                                        <li class="list-group-item">Cruce Manuel Altamirano y Gpe. Victoria</li>
+                                                        <li class="list-group-item">Cruce Manuel doblado y Matamoros</li>
+                                                        <li class="list-group-item">Cruce Matamoros y Morelos</li>
+                                                        <li class="list-group-item">Cruce H. Garza y Moctezuma</li>
+                                                        <li class="list-group-item">Gonzalez Gallo</li>
+                                                        <li class="list-group-item">Oxxo Gonzalez Gallo</li>
+                                                        <li class="list-group-item">Escuela 5 de mayo</li>
+                                                        <li class="list-group-item">Cruce Gral Anaya y González Hermosillo</li>
+                                                        <li class="list-group-item">Gral Anaya y Aquiles Serdán</li>
+                                                        <li class="list-group-item">Cruce Hda. la Trasquila y Mirandilla</li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="accordion-item">
+                                            <h3 class="accordion-header" id="headingC02_2">
+                                                <button class="accordion-button collapsed fs-4" type="button" data-bs-toggle="collapse" data-bs-target="#collapseC02_2" aria-expanded="false" aria-controls="collapseC02_2">
+                                                    Rutas de Camión C02
+                                                </button>
+                                            </h3>
+                                            <div id="collapseC02_2" class="accordion-collapse collapse" aria-labelledby="headingC02_2" data-bs-parent="#accordionC02">
+                                                <div class="accordion-body">
+                                                    <ul class="list-group list-group-flush fs-5">
+                                                        <li class="list-group-item">Cruce Josefa Ortiz y Galeana</li>
+                                                        <li class="list-group-item">Cruce Galeana y Zaragoza</li>
+                                                        <li class="list-group-item">Cruce Pedro Medina y Colón</li>
+                                                        <li class="list-group-item">Cruce Pedro Medina y 5 de Febrero</li>
+                                                        <li class="list-group-item">IMSS Familiar</li>
+                                                        <li class="list-group-item">Policlinica</li>
+                                                        <li class="list-group-item">Central</li>
+                                                        <li class="list-group-item">Río</li>
+                                                        <li class="list-group-item">Unidad deportiva Morelos</li>
+                                                        <li class="list-group-item">Cruce Revolución y Niños Héroes</li>
+                                                        <li class="list-group-item">Cruce Calle y Privada Manuel Altamirano</li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <button class="btn ver-graficos w-20 mx-auto d-block toggle-ruta" onclick="window.location.href='./mapa.html'">
+                                    <i class="bi bi-map me-1"></i> Ver gráfico de la ruta
+                                </button>
+                            </div>
                         </div>
-            
-                        <!-- Segunda columna de rutas para camion_2 -->
-                        <div class="column">
-                            <ul style="list-style-type: disc;">
-                                <li>Cruce Josefa Ortiz y Galeana</li>
-                                <li>Cruce Galeana y Zaragoza</li>
-                                <li>Cruce Pedro Medina y Colón</li>
-                                <li>Cruce Pedro Medina y 5 de Febrero</li>
-                                <li>IMSS Familiar</li>
-                                <li>Policlinica</li>
-                                <li>Central</li>
-                                <li>Río</li>
-                                <li>Unidad deportiva Morelos</li>
-                                <li>Cruce Revolución y Niños Héroes</li>
-                                <li>Cruce Calle y Privada Manuel Altamirano</li>
-                            </ul>
-                        </div>
-                        <button class="ver-graficos" onclick="window.location.href = './mapa.html'">Ver grafico de la ruta</button>
                     </div>
                 </div>
             </section>
         </div>
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Se centraron las tarjetas de camiones en pantallas pequeñas (móviles) para mejorar la visualización y el diseño responsivo.

Se configuraron las listas desplegables (dropdowns) de las rutas de los camiones para que ocupen el tamaño completo disponible dentro de su contenedor.

Se modificaron los estilos para evitar que las listas cambien de tamaño al expandir o contraer los elementos de las dropdowns.

